### PR TITLE
fix off by one

### DIFF
--- a/overdrive.sh
+++ b/overdrive.sh
@@ -147,7 +147,7 @@ download() {
       -H "ClientID: $ClientID" \
       --compressed -o "$output" \
       "$baseurl/$path"
-  done < <(xmlstarlet sel -t -v '//Part/@filename' "$1" | tr \\ / | sed -e "s/{/%7B/" -e "s/}/%7D/")
+  done < <(xmlstarlet sel -t -v '//Part/@filename' -n "$1" | tr \\ / | sed -e "s/{/%7B/" -e "s/}/%7D/")
 }
 
 early_return() {


### PR DESCRIPTION
`xmlstarlet` (at least on Linux and Windows) by default doesn't append a newline to the end of its output and this causes the last filename to be skipped by `while read -r path` which uses a newline for its delimiter. 