### PR TITLE
[curl] Silent downloads within loop

### DIFF
--- a/overdrive.sh
+++ b/overdrive.sh
@@ -150,7 +150,7 @@ download() {
       >&2 printf 'Output already exists: %s\n' "$output"
     else
       >&2 printf 'Downloading %s\n' "$output"
-      if curl -L \
+      if curl -sL \
           -A "$UserAgent" \
           -H "License: $(cat "$license_path")" \
           -H "ClientID: $ClientID" \


### PR DESCRIPTION
Curl requests can get noisy due to the progress meter, especially when it runs within a loop:
<img width="878" alt="Screenshot 2019-04-17 at 2 57 13 PM" src="https://user-images.githubusercontent.com/4201494/56277217-8f72ef00-6121-11e9-94fc-85bc77666ea3.png">

Make the within-loop curl request silent.