### PR TITLE
Added update functionality

### DIFF
--- a/overdrive.sh
+++ b/overdrive.sh
@@ -4,8 +4,7 @@ set -e # exit immediately on first error
 set -o pipefail # propagate intermediate pipeline errors
 
 # should match `git describe --tags` with clean working tree
-# tick up to 2.3.3.1?
-VERSION=2.3.3
+VERSION=2.3.3.1
 
 OMC=1.2.0
 OS=10.11.6


### PR DESCRIPTION
Added self-update functionality. `overdrive.sh --update` grabs the latest version from a [static link](https://raw.githubusercontent.com/chbrown/overdrive/master/overdrive.sh), writes it to a temporary file, mirrors the permissions from the original script, then finally overwrites the original script. It is based on [this question](https://stackoverflow.com/questions/8595751/is-this-a-valid-self-update-approach-for-a-bash-script) from Stack Overflow. Hope someone finds it useful, issuing the command from CLI might be easier than firing up the browser and checking GitHub for new versions.