### PR TITLE
Use system version of printf to support n$

### DIFF
--- a/overdrive.sh
+++ b/overdrive.sh
@@ -3,6 +3,9 @@
 set -e # exit immediately on first error
 set -o pipefail # propagate intermediate pipeline errors
 
+# prefer system version of printf
+enable -n printf
+
 # should match `git describe --tags` with clean working tree
 VERSION=2.3.3
 


### PR DESCRIPTION
The bash builtin version of `printf` does not support the `n$` format character. This allows the format string to use the input values out of order. For example:

`overdrive -o '%2$s - %1$s' download example.odm` will print `{Title} - {Author}` instead of the default value. That format string fails with the bash builtin.